### PR TITLE
Make "success" / "failed" grammar consistent

### DIFF
--- a/test_host_pool.py
+++ b/test_host_pool.py
@@ -5,10 +5,10 @@ import host_pool
 
 
 def test_basic():
-    pool = host_pool.HostPool(['a','b','c'])
+    pool = host_pool.HostPool(['a', 'b', 'c'])
     assert [pool.get(), pool.get(), pool.get(), pool.get()] == ['a', 'b', 'c', 'a']
-    pool.failed('a')
-    pool.failed('b')
+    pool.failure('a')
+    pool.failure('b')
     assert pool.get() == 'c'
     pool.success('c')
     assert pool.get() == 'c'
@@ -16,13 +16,14 @@ def test_basic():
     pool.success('a')
     assert pool.get() in ['a', 'c']
 
+
 def test_raise_no_hosts_available():
     pool = host_pool.HostPool(['a'])
-    pool.failed('a')
+    pool.failure('a')
     assert pool.get() == 'a'
 
     pool = host_pool.HostPool(['a'], reset_on_all_failed=False)
-    pool.failed('a')
+    pool.failed('a')  # Test deprecated HostPool.failed, which should be called as HostPool.failure
     try:
         pool.get()
     except host_pool.NoHostsAvailable:


### PR DESCRIPTION
"success" is a noun, while "failed" is an adjective. It's confusing to have to remember which type of word to use for a successful request vs a failed request.

I propose we change to `HostPool.success` and `HostPool.failure` (`successful` in `successful`, `failed` seems too wordy), while keeping `failed` and marking it as deprecated in the comments.