### PR TITLE
no need for intermediate custom Error class ?

### DIFF
--- a/host_pool.py
+++ b/host_pool.py
@@ -10,11 +10,7 @@ import time
 __version__ = "0.2"
 
 
-class Error(Exception):
-    pass
-
-
-class NoHostsAvailable(Error):
+class NoHostsAvailable(Exception):
     pass
 
 


### PR DESCRIPTION
Consider this a question with attached diff, and feel free to just close.

What is the custom `Error` class for?
cc @davemarchevsky 
